### PR TITLE
Some fixes and new features

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ six
 pyyaml
 Crypto
 pycrypto
+filechunkio

--- a/src/jcsclient/dss.py
+++ b/src/jcsclient/dss.py
@@ -55,6 +55,8 @@ class Controller(object):
                               'complete_multipart_upload',
                               'abort_multipart_upload',
                               'list_multipart_uploads',
+                              'download_folder',
+                              'rename_object',
                              ]
 
     def __getattr__(self, name):

--- a/src/jcsclient/dss_api/dss_main.py
+++ b/src/jcsclient/dss_api/dss_main.py
@@ -43,7 +43,7 @@ class DSS(object):
         5. process the result to make it compatible with the cli driver
         6. return the result
         """
-        
+   
         op_factory = DSSOpFactory()
         op = op_factory.get_op(args[0])
         if(op is None):
@@ -98,5 +98,9 @@ class DSSOpFactory(object):
 			return ListPartsOp()
         if(cli_action == 'upload-part'):
 			return UploadPartOp()
+        if(cli_action == 'download-folder'):
+			return DownloadFolderOp()
+        if(cli_action == 'rename-object'):
+			return RenameObjectOp()
         
         return None

--- a/src/jcsclient/dss_api/dss_object_ops.py
+++ b/src/jcsclient/dss_api/dss_object_ops.py
@@ -21,9 +21,11 @@
 #
 
 from dss_op import *
+from dss_bucket_ops import *
 from dss_auth import *
 from jcsclient import utils
 import os
+import math
 import sys
 import time
 import hmac
@@ -35,6 +37,10 @@ from email.utils import formatdate
 import xml.sax
 import json
 from jcsclient import output
+import xmltodict
+from filechunkio import FileChunkIO
+
+
 
 class ObjectOp(DSSOp):
 
@@ -96,6 +102,63 @@ class HeadObjectOp(ObjectOp):
 
         return result
 
+class MultipartUpload(object):
+
+    def __init__(self, bucketName, objectName, chunkSize = 5*1024*1024*1024):
+        self.bucketName = bucketName
+        self.objectName = objectName
+        self.chunkSize = chunkSize
+
+    def initiate(self):
+        print("\nInitiating multipart upload")
+        op = InitMPUploadOp()
+        op.parse_args(["", "--bucket", self.bucketName, "--key", self.objectName])
+        resp = op.execute()
+        op.raise_for_failure(resp)
+        self.uploadId = xmltodict.parse(resp.content)["InitiateMultipartUploadResult"]["UploadId"]
+        self.numParts = 0
+        self.parts = []
+        op.process_result(resp)
+        output.format_result(resp)
+    
+    def cancel(self):
+        pass
+
+    def listParts(self):
+        pass
+
+    def partsToXML(self):
+        s = '<CompleteMultipartUpload>\n'
+        for (partNum, partEtag) in self.parts:
+            s += '  <Part>\n'
+            s += '    <PartNumber>%d</PartNumber>\n' % partNum
+            s += '    <ETag>%s</ETag>\n' % partEtag
+            s += '  </Part>\n'
+        s += '</CompleteMultipartUpload>'
+        return s
+
+    def uploadPart(self, partNum, fp, size):
+        print("\nUploading part number " + str(partNum))
+        op = UploadPartOp()
+        op.parse_args(["","--bucket", self.bucketName, "--key", self.objectName, "--upload-id", self.uploadId, "--part-number", str(partNum), "--body", ""])
+
+        resp = op.execute(fp, size)
+        op.raise_for_failure(resp)
+        partEtag = resp.headers["etag"]
+        self.numParts += 1
+        self.parts.append((partNum, partEtag))
+        output.format_result(resp)
+
+    def complete(self):
+        print("\nCompleting multipart upload")
+        op = CompleteMPUploadOp()
+        op.parse_args(["","--bucket", self.bucketName, "--key", self.objectName, "--upload-id", self.uploadId, "--multipart-upload", ""])
+        xmlStr = self.partsToXML()
+        resp = op.execute(xmlStr)
+        op.process_result(resp)
+        output.format_result(resp)
+        return None
+
 
 
 class PutObjectOp(ObjectOp):
@@ -121,6 +184,12 @@ class PutObjectOp(ObjectOp):
     def validate_args(self):
         pass
 
+    def get_object_name_from_path(self, path):
+        normalized_path = os.path.normpath(path)
+        path_without_drive = os.path.splitdrive(normalized_path)[1]
+        return path_without_drive.replace(os.sep, "/")
+    
+    
     def execute(self):
         result = None
         # check if the local_file_name is a directory or not
@@ -128,36 +197,47 @@ class PutObjectOp(ObjectOp):
             # recursivley upload all the files and subfolders
 
             self.local_file_name = os.path.normpath(self.local_file_name)
+            object_style_local_file_name = self.get_object_name_from_path(self.local_file_name)
             dir_name = self.object_name
             # create top level folder
             print ("\nCreating folder " + self.object_name)
-            result = self.put_single_object(os.path.normpath(self.object_name) + "/", None, is_folder = True)
+            (result, processResult) = self.put_single_object(os.path.normpath(self.object_name) + "/", self.local_file_name, is_folder = True)
             self.process_result(result)
             output.format_result(result)
             for root, dirs, files in os.walk(self.local_file_name):
                 # iterate over files 
                 for name in files:
                     input_file_path = os.path.join(root, name)
-                    object_name = dir_name + "/" + os.path.normpath(input_file_path[len(self.local_file_name) + 1:])
+                    object_name = dir_name + "/" + self.get_object_name_from_path(input_file_path)[len(object_style_local_file_name) + 1:]
                     print ("\nUploading file " + input_file_path + " as " + object_name)
-                    result = self.put_single_object(object_name, input_file_path)
-                    self.process_result(result)
+                    result, processResult = self.put_single_object(object_name, input_file_path)
+                    if(processResult):
+                        self.process_result(result)
                     output.format_result(result)
                 # iterate over sub directories
                 for name in dirs:
                     input_file_path = os.path.join(root, name)
-                    object_name = dir_name + "/" + os.path.normpath(input_file_path[len(self.local_file_name) + 1:]) + "/"
+                    object_name = dir_name + "/" + self.get_object_name_from_path(input_file_path)[len(object_style_local_file_name) + 1:] + "/"
                     print ("\nCreating folder " + object_name)
-                    result = self.put_single_object(object_name, input_file_path, True)
-                    self.process_result(result)
+                    result, processResult = self.put_single_object(object_name, input_file_path, True)
+                    if(processResult):
+                        self.process_result(result)
                     output.format_result(result)
                   
 
             return None
         else:
-            return self.put_single_object(self.object_name, self.local_file_name)
+            result, processResult = self.put_single_object(self.object_name, self.local_file_name)
+            if(processResult):
+                return result
+            else:
+                return None
 
     def put_single_object(self, object_name, input_file_path, is_folder = False):
+        statinfo = os.stat(input_file_path)
+        if(not is_folder and statinfo.st_size > 5*1024*1024*1024):
+            return (self.put_single_object_multipart(object_name, input_file_path), False)
+          
         self.dss_op_path = '/' + self.bucket_name + '/' + object_name
         self.dss_op_path = urllib2.quote(self.dss_op_path.encode("utf8"))
         # get signature
@@ -166,8 +246,10 @@ class PutObjectOp(ObjectOp):
         signature = auth.get_signature()
         self.http_headers['Authorization'] = signature
         self.http_headers['Date'] = date_str
-        statinfo = os.stat(self.local_file_name)
-        self.http_headers['Content-Length'] = statinfo.st_size
+        if(is_folder):
+          self.http_headers['Content-Length'] = 0
+        else:
+          self.http_headers['Content-Length'] = statinfo.st_size
         self.http_headers['Content-Type'] = 'application/octet-stream'
 
         # construct request
@@ -177,9 +259,23 @@ class PutObjectOp(ObjectOp):
           data = open(input_file_path, 'rb')
         # make request
         resp = requests.put(request_url, headers = self.http_headers, data=data, verify = self.is_secure_request)
-        return resp
+        return (resp, True)
 
-
+    def put_single_object_multipart(self, object_name, input_file_path):
+        part_size = 5*1024*1024*1024
+        statinfo = os.stat(input_file_path)
+        total_size = statinfo.st_size
+        print("\nPerforming multipart upload as the size of file " + input_file_path + " is greater that 5GB : " + str(total_size))
+        part_count = int(math.ceil(total_size / float(part_size)))
+        mp = MultipartUpload(self.bucket_name, object_name)
+        mp.initiate()
+        for i in range(part_count):
+            offset = part_size * i
+            bytes = min(part_size, total_size - offset)
+            with FileChunkIO(input_file_path, 'r', offset=offset, bytes=bytes) as fp:
+                mp.uploadPart(i + 1, fp, bytes)
+        return mp.complete()
+        
     def process_result(self, result):
         # nonop currently, just dump a json in case of success
         if(result is not None and result.status_code == 200):
@@ -238,7 +334,7 @@ class GetObjectOp(ObjectOp):
         with open(self.local_file_name, 'wb') as handle:
             resp = requests.get(request_url, headers = self.http_headers, stream = True, verify = self.is_secure_request)
             if resp.ok:
-                for block in resp.iter_content(1024):
+                for block in resp.iter_content(10240):
                     handle.write(block)
             else:
                 resp.raise_for_status()
@@ -259,6 +355,105 @@ class GetObjectOp(ObjectOp):
             self.pretty_print_json_str(response_json)
         
         return result
+
+
+class DownloadFolderOp(ObjectOp):
+    
+    def __init__(self):
+        ObjectOp.__init__(self)
+        self.http_method = 'GET'
+
+    def parse_args(self, args):
+        params = {}
+        args = args[1:]
+        parser = utils.get_argument_parser()
+        parser.add_argument('--bucket', required=True)
+        parser.add_argument('--key', required=True)
+        parser.add_argument('--outdir', required=True)
+        parser.add_argument('--complete-bucket', action='store_true')
+        args = parser.parse_args(args)
+        args_dict = vars(args)
+        self.bucket_name = args_dict['bucket']
+        self.object_name = args_dict['key']
+        self.local_dir_name = args_dict['outdir'] 
+        if(args_dict['complete_bucket'] is not None):
+            self.download_complete_bucket = True
+        else:
+            self.download_complete_bucket = False
+            
+
+
+    def validate_args(self):
+        pass
+
+    def check_and_raise_for_zero_size(self, key):
+        #check if the given folder object is of size 0
+        op = HeadObjectOp()
+        op.parse_args(["", "--bucket", self.bucket_name, "--key", key])
+        res = op.execute()
+        self.raise_for_failure(res)
+        size = res.headers.get('content-length')
+        if(size != "0"):
+            print ("\nGiven folder " + key + " is not a zero size object in DSS, size is " + size)
+            exit()
+        
+    def create_folder_for_object(self, key):
+        os_style_key_name = key.replace("/", os.sep)
+        joined_path = self.local_dir_name + os.sep + os_style_key_name
+        path = os.path.normpath(joined_path)
+        dirname = os.path.dirname(path)
+        if(not os.path.exists(dirname)):
+            print ("\nCreating folder " + dirname)
+            os.makedirs(dirname)
+        return path
+
+
+    def execute(self):
+        if(not self.download_complete_bucket):
+            self.check_and_raise_for_zero_size(self.object_name)
+        nextMarker = None
+        while(True):
+            op = ListObjectsOp()
+            if(not self.download_complete_bucket):
+                if(nextMarker is None):
+                    op.parse_args(["", "--bucket", self.bucket_name, "--prefix", self.object_name])
+                else:
+                    op.parse_args(["", "--bucket", self.bucket_name, "--prefix", self.object_name, "--starting-token", nextMarker])
+            else:
+                if(nextMarker is None):
+                    op.parse_args(["", "--bucket", self.bucket_name])
+                else:
+                    op.parse_args(["", "--bucket", self.bucket_name, "--starting-token", nextMarker])
+
+            res = op.execute()
+            self.raise_for_failure(res)
+            responseDict = xmltodict.parse(res.content)
+            isTruncated = responseDict.get("ListBucketResult").get("IsTruncated")
+            contents = responseDict.get("ListBucketResult").get("Contents")
+            if(len(contents) == 0):
+                nextMarker = None
+            else:
+                nextMarker = contents[-1].get("Key")
+  
+            for content in contents:
+                key = content.get("Key")
+                if(key.endswith("/")):
+                    #this is a folder
+                    self.check_and_raise_for_zero_size(key)
+                else:
+                    download_path = self.create_folder_for_object(key)
+                    print ("\nDownloading " + key + " to " + download_path)
+                    op = GetObjectOp()
+                    op.parse_args(["", "--bucket", self.bucket_name, "--key", key, "--outfile", download_path])
+                    resp = op.execute()
+                    op.process_result(resp)
+                    output.format_result(resp)
+                    
+            
+            if(isTruncated == "false"):
+                break
+                
+        return None
 
 
 class GetPresignedURLOp(ObjectOp):
@@ -399,19 +594,34 @@ class ListPartsOp(ObjectOp):
         parser.add_argument('--bucket', required=True)
         parser.add_argument('--key', required=True)
         parser.add_argument('--upload-id', required=True)
+        parser.add_argument('--outfile')
         args = parser.parse_args(args)
         args_dict = vars(args)
         self.bucket_name = args_dict['bucket']
         self.object_name = args_dict['key']
         self.upload_id = args_dict['upload_id']
+        self.outfile = args_dict['outfile']
         self.dss_op_path = '/' + self.bucket_name + '/' + self.object_name
         self.dss_op_path = urllib2.quote(self.dss_op_path.encode("utf8"))
-        self.dss_query_str = 'uploadId=' + self.upload_id
+        self.dss_query_str = 'uploadId=' + self.upload_id + "&max-parts=2048"
         self.dss_query_str_for_signature = 'uploadId=' + self.upload_id
 
 
     def execute(self):
         resp = self.make_request()
+        if(self.outfile is not None):
+            self.raise_for_failure(resp)
+            parts = xmltodict.parse(resp.content)["ListPartsResult"]["Part"]
+            s = '<CompleteMultipartUpload>\n'
+            for part in parts:
+                s += '  <Part>\n'
+                s += '    <PartNumber>%s</PartNumber>\n' % part["PartNumber"]
+                s += '    <ETag>%s</ETag>\n' % part["ETag"]
+                s += '  </Part>\n'
+            s += '</CompleteMultipartUpload>'
+            fp = open(self.outfile, "w")
+            fp.write(s)
+            fp.close()
         return resp
 
 
@@ -443,7 +653,7 @@ class UploadPartOp(ObjectOp):
         self.dss_query_str_for_signature = 'partNumber=' + self.part_number + '&uploadId=' + self.upload_id
 
 
-    def execute(self):
+    def execute(self, fp = None, size = None):
         # get signature
         date_str = formatdate(usegmt=True)
         query_str = 'partNumber=' + self.part_number + '&uploadId=' + self.upload_id
@@ -451,18 +661,33 @@ class UploadPartOp(ObjectOp):
         signature = auth.get_signature()
         self.http_headers['Authorization'] = signature
         self.http_headers['Date'] = date_str
-        statinfo = os.stat(self.local_file_name)
-        self.http_headers['Content-Length'] = statinfo.st_size
+        if(fp is None and size is None):
+            statinfo = os.stat(self.local_file_name)
+            self.http_headers['Content-Length'] = statinfo.st_size
+        else:
+            self.http_headers['Content-Length'] = size
+            
         self.http_headers['Content-Type'] = 'application/octet-stream'
 
         # construct request
         request_url = self.dss_url + self.dss_op_path
         if(self.dss_query_str is not None):
             request_url += '?' + self.dss_query_str  
-        data = open(self.local_file_name, 'rb')
+        if(fp is None):
+            data = open(self.local_file_name, 'rb')
+        else:
+            data = fp
         # make request
-        resp = requests.put(request_url, headers = self.http_headers, data=data, verify = self.is_secure_request)
-      
+        resp = None
+        if(fp is None and size is None):
+            resp = requests.put(request_url, headers = self.http_headers, data=data, verify = self.is_secure_request)
+        else:
+            s = requests.Session()
+            req = requests.Request('PUT', request_url, headers = self.http_headers, data=data)
+            prepped = req.prepare()
+            prepped.headers['Content-Length'] = size
+            resp = s.send(prepped, verify = self.is_secure_request)
+            self.process_result(resp)
         return resp
 
 
@@ -473,8 +698,6 @@ class UploadPartOp(ObjectOp):
                       '"ETag": "' + result.headers['etag'].replace('"', '\\"') + '"'
                       '}')
             self.pretty_print_json_str(response_json)
-            resp_json = resp_json.replace("\\", "")
-            print(resp_json)
 
         return result
 
@@ -505,27 +728,72 @@ class CompleteMPUploadOp(ObjectOp):
         self.dss_query_str_for_signature = 'uploadId=' + self.upload_id
 
 
-    def execute(self):
+    def execute(self, xmlStr = None):
         # get signature
         date_str = formatdate(usegmt=True)
         auth = DSSAuth(self.http_method, self.access_key, self.secret_key, date_str, self.dss_op_path, query_str = self.dss_query_str_for_signature, content_type = 'text/xml')
         signature = auth.get_signature()
         self.http_headers['Authorization'] = signature
         self.http_headers['Date'] = date_str
-        statinfo = os.stat(self.local_file_name)
-        self.http_headers['Content-Length'] = statinfo.st_size
+        if(xmlStr is None):
+            statinfo = os.stat(self.local_file_name)
+            self.http_headers['Content-Length'] = statinfo.st_size
+        else:
+            self.http_headers['Content-Length'] = len(xmlStr)
         self.http_headers['Content-Type'] = 'text/xml'
 
         # construct request
         request_url = self.dss_url + self.dss_op_path
         if(self.dss_query_str is not None):
             request_url += '?' + self.dss_query_str  
-        data = open(self.local_file_name, 'rb')
+        if(xmlStr is None):
+            data = open(self.local_file_name, 'rb')
+        else:
+            data = xmlStr
         # make request
         resp = requests.post(request_url, headers = self.http_headers, data=data, verify = self.is_secure_request)
       
         # process response
         processed_resp = self.process_result(resp)
         return processed_resp
+
+
+
+class RenameObjectOp(ObjectOp):
+    
+    def __init__(self):
+        ObjectOp.__init__(self)
+        self.http_method = 'PUT'
+
+    def parse_args(self, args):
+        params = {}
+        args = args[1:]
+        parser = utils.get_argument_parser()
+        parser.add_argument('--bucket', required=True)
+        parser.add_argument('--key', required=True)
+        parser.add_argument('--new-name', required=True)
+        args = parser.parse_args(args)
+        args_dict = vars(args)
+        self.bucket_name = args_dict['bucket']
+        self.object_name = args_dict['key']
+        self.new_name = args_dict['new_name'] 
+
+    def execute(self):
+        self.dss_op_path = '/' + self.bucket_name + '/' + self.object_name 
+        self.dss_op_path = urllib2.quote(self.dss_op_path.encode("utf8"))
+        # get signature
+        date_str = formatdate(usegmt=True)
+        auth = DSSAuth(self.http_method, self.access_key, self.secret_key, date_str, self.dss_op_path, content_type = 'application/octet-stream')
+        signature = auth.get_signature()
+        self.http_headers['Authorization'] = signature
+        self.http_headers['Date'] = date_str
+        self.http_headers['Content-Type'] = 'application/octet-stream'
+
+        # construct request
+        query_params = "?newname=" + urllib2.quote(self.new_name.encode("utf8"))
+        request_url = self.dss_url + urllib2.quote(self.dss_op_path.encode("utf8")) + query_params
+        # make request
+        resp = requests.put(request_url, headers = self.http_headers, data=None, verify = self.is_secure_request)
+        return resp
 
 

--- a/src/jcsclient/dss_api/dss_op.py
+++ b/src/jcsclient/dss_api/dss_op.py
@@ -97,4 +97,13 @@ class DSSOp(object):
         resp_json = resp_json.replace("\\", "")
         print(resp_json)
 
+    def raise_for_failure(self, res):
+        status = res.status_code
+        if status != 200 and status != 204:
+            output_msg = "\nRequest-Id: " + res.headers.get('x-jcs-request-id')
+            print(output_msg)
+            res.raise_for_status()
+            
+
+
 

--- a/src/jcsclient/help_topics/dss.txt
+++ b/src/jcsclient/help_topics/dss.txt
@@ -28,6 +28,8 @@ AVAILABLE COMMANDS :
     complete-multipart-upload
     abort-multipart-upload
     list-multipart-uploads
+    download-folder
+    rename-object
 
 
 To see detailed help for any command, type

--- a/src/jcsclient/help_topics/dss/download-folder.txt
+++ b/src/jcsclient/help_topics/dss/download-folder.txt
@@ -1,0 +1,30 @@
+Name
+    download-folder
+    
+Description
+    Retrieves folders or complete bucket from dss
+
+Synopsis
+    download-folder
+    --bucket <value>
+    --key <value>
+    --outdir <value>
+    [--complete-bucket]
+  
+Options
+    --bucket (string)
+
+    --key (string) folder name. must end with "/"
+
+    --outdir (string) local directory to which contents are downloaded
+
+    --complete-bucket (optional) if this is set, key argument is ignored and the entire bucket is downloaded
+
+Examples
+    The following example uses the download-folder command to download a folder from dss:
+
+    jcs dss download-folder --bucket text-content --key folder1/ --outdir ./local_dir
+    
+    The following example uses the download-folder command to download a bucket from dss:
+
+    jcs dss download-folder --bucket text-content --key folder1/ --outdir ./local_dir --complete-bucket

--- a/src/jcsclient/help_topics/dss/list-parts.txt
+++ b/src/jcsclient/help_topics/dss/list-parts.txt
@@ -17,9 +17,15 @@ Options
 
     --upload-id (string) Upload ID identifying the multipart upload whose parts are being listed.
 
+    --outfile (string) optional - create a xml file at this path containg the part numbers and etags. 
+      this file can be used in complete-multipart-upload
+
 Examples
     The following command lists all of the parts that have been uploaded for a multipart upload with key mp1
     in the bucket mybucket:
 
     jcs dss list-parts --bucket mybucket --key 'mp1' --upload-id
     bkOyypJJx2iGklFYxhX7f2v4oHVYjxc
+    
+    jcs dss list-parts --bucket mybucket --key 'mp1' --upload-id
+    bkOyypJJx2iGklFYxhX7f2v4oHVYjxc --outfile ./mp.xml

--- a/src/jcsclient/help_topics/dss/rename-object.txt
+++ b/src/jcsclient/help_topics/dss/rename-object.txt
@@ -1,0 +1,27 @@
+Name
+    rename-object
+
+Description
+    Rename an object already uploaded.
+
+Synopsis
+    rename-object
+    --bucket <value>
+    --key <value>
+    --new-name <value>
+      
+      
+Options
+
+
+      --bucket (string) Name of the bucket in which the object is to be updated.
+
+      --key (string) current name of the key.
+
+      --new-name (string) new name to be given to the key.
+
+
+Examples
+    The following example uses the rename-object command to rename an object in dss:
+
+    jcs dss  rename-object --bucket mybucket --key myobj --new-name myobj_new


### PR DESCRIPTION
JJC-53: DSS - download entire folders or bucket
JOS-103: jcs dss upload part giving error "resp_json reffered before assignment
JJC-44A: way for user to get XML file in list-parts operation to be used in DSS complete-multipart-upload operation in JCS CLI
JJC-46: Implementation of DSS RENAME API in CLI
JJC-48: DSS Upload Folder functionality not working on Windows
JJC-50: DSS - Upload Part CLI output displays internal Python script validation error
